### PR TITLE
Update link in index.html

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -26,7 +26,7 @@
             from the exchange item located in ACC. <br/>
             This workflow focuses on the part of the Data Exchange GraphQL API, needed to navigate through hubs, projects,
             folders and identifying the exchange item.<br /><br/>
-            <a class="btn btn-primary" href="/1-DesignValidation">Go to sample</a>
+            <a class="btn btn-primary" href="/1-ExchangeItemInfo">Go to sample</a>
         </div>
         <hr />
         <div>


### PR DESCRIPTION
Fixes a stale link to the first sub-page.  We want to link to /1-ExchangeItemInfo.
